### PR TITLE
Make Quick Start more approachable

### DIFF
--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -46,7 +46,7 @@ from pyramid.view import view_config
 
 @view_config(route_name='hello', renderer='string')
 def hello_world(request):
-    return 'Hello World!'
+    return 'Hello World'
 
 if __name__ == '__main__':
     config = Configurator()
@@ -54,12 +54,7 @@ if __name__ == '__main__':
     config.scan()
     app = config.make_wsgi_app()
     server = make_server('0.0.0.0', 8080, app)
-    server.serve_forever()</code>
-          </pre>
-          <pre class="nobs">
-            <code class="bash">$ pip install Pyramid
-$ python hello.py
-# Point browser to http://localhost:8080</code>
+    server.serve_forever() </code>
           </pre>
         </div>
         <div class="col-md-6">

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -42,18 +42,24 @@
           <pre class="nobs">
             <code class="python">from wsgiref.simple_server import make_server
 from pyramid.config import Configurator
-from pyramid.response import Response
+from pyramid.view import view_config
 
+@view_config(route_name='hello', renderer='string')
 def hello_world(request):
-    return Response('Hello %(name)s!' % request.matchdict)
+    return 'Hello World!'
 
 if __name__ == '__main__':
     config = Configurator()
-    config.add_route('hello', '/hello/{name}')
-    config.add_view(hello_world, route_name='hello')
+    config.add_route('hello', '/')
+    config.scan()
     app = config.make_wsgi_app()
     server = make_server('0.0.0.0', 8080, app)
     server.serve_forever()</code>
+          </pre>
+          <pre class="nobs">
+            <code class="bash">$ pip install Pyramid
+$ python hello.py
+# Point browser to http://localhost:8080</code>
           </pre>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
At DragonSprint we sent people over the Flask front page. Then we sent them over
the TryPyramid front page. Both “above the fold“. The difference was staggering:
all managed to start the Flask example and got a browser to render “Hello
World“. And none managed to do it with Pyramid without help or frustration.

This is our attempt to make TryPyramid QuickStart example more approachable.

Change 1: the Quick Start code configures the view imperatively and the Pyramid
Feature sections provide declarative examples. Lets promote a single way of view configuration, at least for newcomers.

Change 2: Every single person who tried the Quick Start code today got stuck
with a 404 Not Found error when running the code and opening it in the browser.
Because one needs to go to ``/hello/foo`` to get a response. This is not obvious
at all and people get stuck. Also, while it is nice to show off some Pyramid
features, let’s keep this example as simple as possible and return a hardcoded
string, on root. Several less things to get stuck on.

![screenshot 2016-12-05 14 51 19](https://cloud.githubusercontent.com/assets/6690754/20887842/9733333a-bafc-11e6-8054-65ed33f71eca.png)
