### PR TITLE
Made hello world code even siplier

### DIFF
--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -40,21 +40,18 @@
       <div class="row">
         <div class="col-md-6">
           <pre class="nobs">
-            <code class="python">from wsgiref.simple_server import make_server
+            <code class="python">from pyramid.scripts.pserve import wsgiref_server_runner
 from pyramid.config import Configurator
 from pyramid.view import view_config
 
-@view_config(route_name='hello', renderer='string')
-def hello_world(request):
+@view_config(renderer='string')
+def hello(request):
     return 'Hello World'
 
 if __name__ == '__main__':
     config = Configurator()
-    config.add_route('hello', '/')
     config.scan()
-    app = config.make_wsgi_app()
-    server = make_server('0.0.0.0', 8080, app)
-    server.serve_forever() </code>
+    wsgiref_server_runner(config.make_wsgi_app(), None)</code>
           </pre>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
We have played code golf even further and managed to make code even simpler.

1. Turns out if you don't pass ``route_name`` to ``view_config`` it will take the function's name as ``route_name`` AND register the route. So the ``config.add_route()`` line is redundant. The idea come from the Narrative Documentation > Application Configuration documentation (http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/configuration.html#declarative-configuration). @miohtama this somewhat provides a bit of what we are trying to do in #2852

2. It also turns out that pyramid already comes with a server runner. It's in ``pscripts`` and as a bonus it prints the following to the console when server starts: ``Starting HTTP server on http://0.0.0.0:8080``. This might make @mfrlin's #2846 redundant.

Here is the new code:
```python
from pyramid.scripts.pserve import wsgiref_server_runner
from pyramid.config import Configurator
from pyramid.view import view_config

@view_config(renderer='string')
def hello(request):
    return 'Hello World'

if __name__ == '__main__':
    config = Configurator()
    config.scan()
    wsgiref_server_runner(config.make_wsgi_app(), None)
```