### PR TITLE
Update Warehouse description and vcs url

### DIFF
--- a/data/poweredBy/apps/warehouse.yaml
+++ b/data/poweredBy/apps/warehouse.yaml
@@ -1,11 +1,10 @@
 category: floss
 demoUrl: https://pypi.org/
-description: <p>Warehouse is a next generation Python Package Repository designed
-  to replace the legacy code base that currently powers PyPI.</p>
+description: <p>Warehouse is the software that powers PyPI.</p>
 docsUrl: https://warehouse.readthedocs.io/
 logo: warehouse-pypi-logo.png
 maintainers: []
 name: warehouse
 projectUrl: https://pypi.org
 pypiUrl: ''
-vcsUrl: https://github.com/pypa/warehouse
+vcsUrl: https://github.com/pypi/warehouse


### PR DESCRIPTION
Randomly saw that the Warehouse description was out of date, so I thought I'd update it.