### PR TITLE
Add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Delta Regeer <xistence@0x58.com> <bertjw@regeer.org>
+Delta Regeer <xistence@0x58.com> <xistence@0x58.com>

--- a/data/addons/pyramid_authsanity.yaml
+++ b/data/addons/pyramid_authsanity.yaml
@@ -5,7 +5,7 @@ demoUrl: ''
 description: Provides a secure authentication policy with an easy to use backend.
 docsUrl: http://pyramid-authsanity.readthedocs.org/en/latest/
 maintainers:
-- Bert JW Regeer
+- Delta Regeer
 name: pyramid_authsanity
 projectUrl: ''
 pypiUrl: https://pypi.org/project/pyramid_authsanity

--- a/data/addons/pyramid_mako.yaml
+++ b/data/addons/pyramid_mako.yaml
@@ -5,7 +5,7 @@ demoUrl: ''
 description: Mako templating bindings for Pyramid.
 docsUrl: http://docs.pylonsproject.org/projects/pyramid-mako/en/latest/
 maintainers:
-- Bert JW Regeer
+- Delta Regeer
 name: pyramid_mako
 projectUrl: ''
 pypiUrl: https://pypi.org/project/pyramid_mako


### PR DESCRIPTION
Adds a `.mailmap` so my commits resolve to my current name and email. It maps
by commit email, which covers every historical variant. Display-only — the
commit objects themselves are unchanged.

Also updates my name in the `pyramid_mako` and `pyramid_authsanity` addon metadata.